### PR TITLE
Fix Pi device connectivity with correct Tailscale IP mappings

### DIFF
--- a/infra/vps/compose.fleet.yml
+++ b/infra/vps/compose.fleet.yml
@@ -9,10 +9,10 @@ services:
     networks:
       - fleet-network
     extra_hosts:
-      - "pi-audio-01:172.18.0.1"
-      - "pi-audio-02:172.18.0.1"
+      - "pi-audio-01:100.127.65.25"
+      - "pi-audio-02:100.122.210.53"
       - "pi-video-01:100.123.206.6"
-      - "pi-camera-01:172.18.0.1"
+      - "pi-camera-01:100.78.196.11"
     environment:
       - NODE_ENV=production
       - API_PORT=3015
@@ -39,10 +39,10 @@ services:
     networks:
       - fleet-network
     extra_hosts:
-      - "pi-audio-01:172.18.0.1"
-      - "pi-audio-02:172.18.0.1"
+      - "pi-audio-01:100.127.65.25"
+      - "pi-audio-02:100.122.210.53"
       - "pi-video-01:100.123.206.6"
-      - "pi-camera-01:172.18.0.1"
+      - "pi-camera-01:100.78.196.11"
     environment:
       - NODE_ENV=production
       - DATABASE_URL=file:/data/fleet.db


### PR DESCRIPTION
## Summary
- Fixed critical device connectivity issue by updating Tailscale IP mappings in compose.fleet.yml
- Backend containers can now reach Pi devices via Tailscale mesh network instead of trying Docker host

## Changes
Updated `extra_hosts` in both `fleet-api` and `fleet-worker` services:
- `pi-audio-01`: 172.18.0.1 → 100.127.65.25
- `pi-audio-02`: 172.18.0.1 → 100.122.210.53  
- `pi-camera-01`: 172.18.0.1 → 100.78.196.11
- `pi-video-01`: 100.123.206.6 ✓ (already correct)

## Impact
- **CRITICAL**: This fix must be deployed before maintenance window
- Without this fix, backend cannot reach Pi devices after worker rebuild
- UI will show devices as offline even when they're online on Tailscale
- Audio/video/camera control functionality will fail

## Test plan
- [x] Verified Pi devices reachable via Tailscale IPs
- [x] Tested device status updates in UI after fix
- [x] Confirmed audio playback on pi-audio-02
- [ ] Deploy and verify all devices show correct online status

🤖 Generated with [Claude Code](https://claude.com/claude-code)